### PR TITLE
Fix outdated syntax in config

### DIFF
--- a/config/blockchain.js
+++ b/config/blockchain.js
@@ -25,13 +25,13 @@ module.exports = {
     maxpeers: 0, // Maximum number of network peers (network disabled if set to 0) (default: 25)
     proxy: false, // Proxy is used to present meaningful information about transactions
     targetGasLimit: 8000000, // Target gas limit sets the artificial target gas floor for the blocks to mine
-    simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm", // Mnemonic  used by the simulator to generate a wallet
     simulatorBlocktime: 0, // Specify blockTime in seconds for automatic mining. Default is 0 and no auto-mining.
-    account: {
+    accounts: [{
+	    mnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm" // Mnemonic  used by the simulator to generate a wallet
       // numAccounts: 3, // When specified, creates accounts for use in the dapp. This option only works in the development environment, and can be used as a quick start option that bypasses the need for MetaMask in development. These accounts are unlocked and funded with the below settings.
       // password: "config/development/password", // Password for the created accounts (as specified in the `numAccounts` setting). If `mineWhenNeeded` is enabled (and isDev is not), this password is used to create a development account controlled by the node.
       // balance: "5 ether" // Balance to be given to the created accounts (as specified in the `numAccounts` setting)
-    }
+    }]
   },
 
   // merges with the settings in default
@@ -59,12 +59,12 @@ module.exports = {
     nodiscover: true,
     maxpeers: 0,
     proxy: true,
-    account: {
+    accounts: [{
+	    mnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm",
       // "address": "", // When specified, uses that address instead of the default one for the network
       password: "config/privatenet/password" // Password to unlock the account. If `mineWhenNeeded` is enabled (and isDev is not), this password is used to create a development account controlled by the node.
-    },
+    }],
     targetGasLimit: 8000000,
-    simulatorMnemonic: "example exile argue silk regular smile grass bomb merge arm assist farm",
     simulatorBlocktime: 0
   },
 
@@ -73,17 +73,17 @@ module.exports = {
   testnet: {
     networkType: "testnet",
     syncMode: "light",
-    account: {
+    accounts: [{
       password: "config/testnet/password"
-    }
+    }]
   },
 
   testnet_devcoin: {
     networkType: "testnet",
     syncMode: "light",
-    account: {
+    accounts: [{
       password: "config/testnet/password"
-    }
+    }]
   },
 
   // merges with the settings in default


### PR DESCRIPTION
embark crashes because the config file is using outdated config params, this PR fixes that.